### PR TITLE
Add deprecation to application exception starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,5 +106,6 @@ apply plugin: 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
 
 - [Authentication](laa-spring-boot-starters/laa-spring-boot-starter-auth/README.md)
 - [Application exception handling](laa-spring-boot-starters/laa-spring-boot-starter-application-exception/README.md)
+  (deprecated – prefer Spring's built-in `ProblemDetail`/`ErrorResponse` RFC 9457 support)
 - [Slack alerts](laa-spring-boot-starters/laa-spring-boot-starter-slack-alerts/README.md)
 - _**[TODO]**_ Entity Converters

--- a/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/README.md
+++ b/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/README.md
@@ -4,6 +4,10 @@ This starter provides a reusable base exception (`ApplicationException`) and a `
 (`GlobalExceptionHandler`) that turn those exceptions into consistent HTTP responses containing the
 `error_message` and `http_status` fields.
 
+> **Deprecated:** Spring Boot now provides native RFC 9457 support via `ProblemDetail` and
+> `ErrorResponse`, which can be returned from any `@ExceptionHandler` or `@RequestMapping` method.
+> Prefer those classes for new work; this starter remains only for legacy applications.
+
 ## Usage
 
 ## Declare the dependency
@@ -27,7 +31,7 @@ the exception into a JSON response body:
      "errorMessage": "Something went wrong",
      "httpStatus": 400
    }
-   ```
+  ```
 
 ## Creating Specific Exceptions
 
@@ -49,5 +53,18 @@ public class SomeException extends ApplicationException {
 ```
 
 Throwing `SomeException` from your application will produce a `400 Bad Request`
-response with the supplied message and the standard error payload. Create additional subclasses for
-other HTTP statuses as required.
+response with the supplied message and the standard error payload. Create additional subclasses for other HTTP statuses as required.
+
+### Recommended alternative (ProblemDetail/ErrorResponse)
+
+Spring now supports returning RFC 9457 responses directly. Instead of using `ApplicationException`,
+return a `ProblemDetail` (or `ErrorResponse`) from your exception handlers or controller methods:
+
+```java
+@ExceptionHandler(SomeException.class)
+ProblemDetail handle(SomeException ex) {
+  return ProblemDetail.forStatusAndDetail(BAD_REQUEST, ex.getMessage());
+}
+```
+
+This approach avoids the custom exception hierarchy and aligns with Spring's built-in HTTP API error handling going forward.

--- a/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/src/main/java/uk/gov/laa/springboot/exception/ApplicationException.java
+++ b/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/src/main/java/uk/gov/laa/springboot/exception/ApplicationException.java
@@ -7,7 +7,12 @@ import org.springframework.http.HttpStatusCode;
 
 /**
  * Exception thrown in the api for application exceptions.
+ *
+ * @deprecated Use Spring's {@link org.springframework.http.ProblemDetail} or
+ *     {@link org.springframework.web.ErrorResponse} support to return RFC 9457 compliant responses
+ *     directly from {@code @ExceptionHandler} or {@code @RequestMapping} methods.
  */
+@Deprecated
 public class ApplicationException extends RuntimeException {
 
   @Getter

--- a/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/src/main/java/uk/gov/laa/springboot/exception/GlobalExceptionHandler.java
+++ b/laa-spring-boot-starters/laa-spring-boot-starter-application-exception/src/main/java/uk/gov/laa/springboot/exception/GlobalExceptionHandler.java
@@ -9,9 +9,14 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 /**
  * Controller advice class responsible for handling exceptions globally and providing appropriate
  * error responses.
+ *
+ * @deprecated Prefer using Spring's {@link org.springframework.http.ProblemDetail} or
+ *     {@link org.springframework.web.ErrorResponse} responses directly from
+ *     {@code @ExceptionHandler} or {@code @RequestMapping} methods.
  */
 @RestControllerAdvice
 @Slf4j
+@Deprecated
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
   /**


### PR DESCRIPTION
## Summary

Due to ProblemDetail/ErrorResponse RFC 9457 support, this starter is now deprecated

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
