### PR TITLE
Fix Gradle repository URL assignment deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ pluginManagement {
     repositories {
         maven {
             name = "gitHubPackages"
-            url uri('https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common')
+            url = uri('https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common')
             credentials {
                 username = System.getenv("GITHUB_ACTOR")?.trim() ?: settings.ext.find('project.ext.gitPackageUser')
                 password = System.getenv("GITHUB_TOKEN")?.trim() ?: settings.ext.find('project.ext.gitPackageKey')
             }
         }
-        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url = uri("https://plugins.gradle.org/m2/") }
         gradlePluginPortal()
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ subprojects {
     publishing.repositories {
         maven {
             name = "GitHubPackages"
-            url "https://maven.pkg.github.com/ministryofjustice/${rootProject.name}"
+            url = uri("https://maven.pkg.github.com/ministryofjustice/${rootProject.name}")
             credentials {
                 username = System.getenv("GITHUB_ACTOR")
                 password = System.getenv("GITHUB_TOKEN")

--- a/laa-java-gradle-plugin/src/main/groovy/uk/gov/laa/gradle/LaaJavaGradlePlugin.groovy
+++ b/laa-java-gradle-plugin/src/main/groovy/uk/gov/laa/gradle/LaaJavaGradlePlugin.groovy
@@ -131,7 +131,7 @@ class LaaJavaGradlePlugin implements Plugin<Project> {
         target.repositories {
             mavenCentral()
             maven {
-                url 'https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common'
+                url = target.uri('https://maven.pkg.github.com/ministryofjustice/laa-spring-boot-common')
                 credentials {
                     username = target.gitHubPackagesUsername
                     password = target.gitHubPackagesPassword
@@ -147,7 +147,7 @@ class LaaJavaGradlePlugin implements Plugin<Project> {
         target.publishing {
             repositories {
                 maven {
-                    url "https://maven.pkg.github.com/ministryofjustice/${repositoryName}"
+                    url = target.uri("https://maven.pkg.github.com/ministryofjustice/${repositoryName}")
                     credentials {
                         username = target.gitHubPackagesUsername
                         password = target.gitHubPackagesPassword


### PR DESCRIPTION
## Summary

Updated Gradle repo declarations to use assignment syntax to clear the Groovy space-assignment deprecation warnings.

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
