### PR TITLE
chore: reduce Javadoc publication size

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,6 +106,7 @@ subprojects {
     // pre-existing (non-standard) Javadoc comments don't fail the build.
     tasks.withType(Javadoc).configureEach {
         options.addStringOption('Xdoclint:none', '-quiet')
+        options.addBooleanOption('-no-fonts', true)
     }
 
     publishing.publications.withType(MavenPublication).configureEach {


### PR DESCRIPTION
### Summary

<img width="1169" height="60" alt="image" src="https://github.com/user-attachments/assets/28f83ccb-c09e-4baa-892e-6db24470dd7d" />


Reduces the size of published Javadoc artifacts by excluding the standard web fonts bundled by Java 25.
Each starter previously included its own copy of these fonts, making the combined Javadoc artifacts 32.31 MiB.

### Results

- Javadoc artifacts reduced from 32.31 MiB to 1.09 MiB
- 96.6% reduction
- Per-module Javadoc and source artifacts remain available
- Maven Central publication requirements remain satisfied

## Checklist

Before you ask people to review this PR, please confirm:

- [ ] The build pipeline is passing.
- [ ] There are no conflicts with the target branch.
- [ ] There are no whitespace-only changes.
- [ ] There are no unexpected changes.
